### PR TITLE
[Feature] #30 Add function that returns safeArea top value

### DIFF
--- a/campair/campair.xcodeproj/project.pbxproj
+++ b/campair/campair.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		A8F7DD7628537C4600A4629E /* UtilityPlaceHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8F7DD7528537C4600A4629E /* UtilityPlaceHolder.swift */; };
 		CC00FAD428574F5F00BA8549 /* EditorDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00FAD328574F5F00BA8549 /* EditorDetailView.swift */; };
 		CC00FADA28581E8E00BA8549 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00FAD928581E8E00BA8549 /* ColorExtension.swift */; };
+		CC00FADC28583B1F00BA8549 /* SafeAreaPadding.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00FADB28583B1F00BA8549 /* SafeAreaPadding.swift */; };
 		CC9D118B28573366000FEC81 /* EditorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9D118A28573366000FEC81 /* EditorViewModel.swift */; };
 		CC9D118D2857336F000FEC81 /* EditorUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9D118C2857336F000FEC81 /* EditorUseCase.swift */; };
 		CC9D118F2857337A000FEC81 /* EditorRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC9D118E2857337A000FEC81 /* EditorRepository.swift */; };
@@ -46,6 +47,7 @@
 		A8F7DD7528537C4600A4629E /* UtilityPlaceHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilityPlaceHolder.swift; sourceTree = "<group>"; };
 		CC00FAD328574F5F00BA8549 /* EditorDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorDetailView.swift; sourceTree = "<group>"; };
 		CC00FAD928581E8E00BA8549 /* ColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtension.swift; sourceTree = "<group>"; };
+		CC00FADB28583B1F00BA8549 /* SafeAreaPadding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeAreaPadding.swift; sourceTree = "<group>"; };
 		CC9D118A28573366000FEC81 /* EditorViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditorViewModel.swift; sourceTree = "<group>"; };
 		CC9D118C2857336F000FEC81 /* EditorUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditorUseCase.swift; sourceTree = "<group>"; };
 		CC9D118E2857337A000FEC81 /* EditorRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditorRepository.swift; sourceTree = "<group>"; };
@@ -122,6 +124,7 @@
 				A884D24F2852CD7C004871B1 /* Assets.xcassets */,
 				A884D24B2852CD7B004871B1 /* CampairApp.swift */,
 				CC00FAD928581E8E00BA8549 /* ColorExtension.swift */,
+				CC00FADB28583B1F00BA8549 /* SafeAreaPadding.swift */,
 				A884D2512852CD7C004871B1 /* Preview Content */,
 			);
 			path = Application;
@@ -333,10 +336,11 @@
 				A884D24E2852CD7B004871B1 /* ContentView.swift in Sources */,
 				CC9D1191285733A2000FEC81 /* Equipment.swift in Sources */,
 				A884D24C2852CD7B004871B1 /* CampairApp.swift in Sources */,
+				CC00FADC28583B1F00BA8549 /* SafeAreaPadding.swift in Sources */,
 				CCAD618E2855A449004B7801 /* EquipmentDictionaryMainView.swift in Sources */,
 				CC9D118D2857336F000FEC81 /* EditorUseCase.swift in Sources */,
 				CC00FADA28581E8E00BA8549 /* ColorExtension.swift in Sources */,
-				CCAD61952855D0F5004B7801 /* ToolDictionaryDetailView.swift in Sources */,
+				CCAD61952855D0F5004B7801 /* EquipmentDictionaryDetailView.swift in Sources */,
 				CCAD61952855D0F5004B7801 /* EquipmentDictionaryDetailView.swift in Sources */,
 				A884D24C2852CD7B004871B1 /* CampairApp.swift in Sources */,
 				A8F7DD7628537C4600A4629E /* UtilityPlaceHolder.swift in Sources */,

--- a/campair/campair/Application/SafeAreaPadding.swift
+++ b/campair/campair/Application/SafeAreaPadding.swift
@@ -1,0 +1,18 @@
+//
+//  SafeAreaPadding.swift
+//  campair
+//
+//  Created by 이가은 on 2022/06/14.
+//
+
+import Foundation
+import SwiftUI
+
+extension UIDevice {
+    /// Returns safeArea top value
+    var getSafeAreaTopValue: CGFloat {
+        guard let window = UIApplication.shared.windows.filter({$0.isKeyWindow}).first
+        else { return 0 }
+        return window.safeAreaInsets.top
+    }
+}

--- a/campair/campair/View/Editor/EditorDetailView.swift
+++ b/campair/campair/View/Editor/EditorDetailView.swift
@@ -48,7 +48,7 @@ struct OpeningEditorView: View {
                     // heavy -> extraBold : 800 숫자로 맞춰야 하는데 숫자를 fontWeight으로 주는 방법을 모르겠습니다.
                         .fontWeight(.heavy)
                 }
-                .padding(.top, 64)
+                .padding(.top, 30 + UIDevice.current.getSafeAreaTopValue)
                 .padding(.leading, 20)
             }
             VStack(alignment: .leading, spacing: 11) {
@@ -149,5 +149,7 @@ struct RecommendedEquipmentCardView: View {
 struct EditorDetailView_Previews: PreviewProvider {
     static var previews: some View {
         EditorDetailView()
+        EditorDetailView()
+            .previewDevice("iPhone SE (3rd generation)")
     }
 }


### PR DESCRIPTION
# Issue Number
🔒 Close #30 

## Changes

- Changed files
    - campair/campair/Application/SafeAreaPadding.swift
    - campair/campair/View/Editor/EditorDetailView.swift

## New features

- Add function that returns safeArea top value

## Review points

- I made a function to get the safeArea top value. Please check the link below for how to use it.
https://github.com/DeveloperAcademy-POSTECH/MC2-Team2-GreedySquirrel/wiki/06.14.tue-:-safeArea-Issue

## References

- https://www.codegrepper.com/code-examples/swift/swiftui+detect+notch
- https://stackoverflow.com/questions/52402477/ios-detect-if-the-device-is-iphone-x-family-frameless

## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
