### PR TITLE
[Feature] #147 #151 To turn off the screen when you drop down the Editor Detail View

### DIFF
--- a/campair/campair.xcodeproj/project.pbxproj
+++ b/campair/campair.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		40610BD9285C5E3600CC7903 /* DictionaryDetailCategory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40610BD8285C5E3600CC7903 /* DictionaryDetailCategory.swift */; };
 		40610BDB285C5E4200CC7903 /* DictionaryEquipmentContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40610BDA285C5E4200CC7903 /* DictionaryEquipmentContent.swift */; };
 		40610BDE285C5F3500CC7903 /* DictionaryMainCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40610BDD285C5F3500CC7903 /* DictionaryMainCollection.swift */; };
-		823A03E07B3007B9DB63E4CA /* Pods_campair.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EEE262B177D80904B01C5D51 /* Pods_campair.framework */; };
 		911531CF28587B7000961E08 /* EditorEquipListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911531CE28587B7000961E08 /* EditorEquipListView.swift */; };
 		911841AF285C5818004E7BB3 /* DictionaryContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911841AE285C5818004E7BB3 /* DictionaryContentView.swift */; };
 		911841B3285C586C004E7BB3 /* EditorDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 911841B2285C586C004E7BB3 /* EditorDetailViewModel.swift */; };
@@ -454,7 +453,6 @@
 		CC9D118A28573366000FEC81 /* EditorMainViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditorMainViewModel.swift; sourceTree = "<group>"; };
 		CC9D118C2857336F000FEC81 /* EditorUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditorUseCase.swift; sourceTree = "<group>"; };
 		CC9D118E2857337A000FEC81 /* EditorRepository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditorRepository.swift; sourceTree = "<group>"; };
-		EEE262B177D80904B01C5D51 /* Pods_campair.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_campair.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F62A6D1B2859B9BC00755AF3 /* DictionaryDetailedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryDetailedView.swift; sourceTree = "<group>"; };
 		F62A6D1D2859BC4400755AF3 /* DictionaryMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DictionaryMainView.swift; sourceTree = "<group>"; };
 		F6AC5584285DD0B3008CA2E4 /* DictionaryDetailCategoryData.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; name = DictionaryDetailCategoryData.json; path = campair/UseCase/DictionaryDetailCategoryData.json; sourceTree = SOURCE_ROOT; };
@@ -466,7 +464,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				823A03E07B3007B9DB63E4CA /* Pods_campair.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -476,7 +473,6 @@
 		0F68B6219A352C19692AE98D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				EEE262B177D80904B01C5D51 /* Pods_campair.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/campair/campair/View/Editor/Detail/EditorDetailView/EditorDetailView.swift
+++ b/campair/campair/View/Editor/Detail/EditorDetailView/EditorDetailView.swift
@@ -19,17 +19,24 @@ struct EditorDetailView: View {
     var body: some View {
         NavigationView {
             ZStack(alignment: .topTrailing) {
-                ScrollViewOffset(color: viewModel.editorDetailContent.openingSection.cardPaintingBackgroundColor) {
+                let backGroundColorOfPaintingString = viewModel.editorDetailContent.openingSection.cardPaintingBackgroundColor
+                Color(hex: backGroundColorOfPaintingString)
+                ScrollViewOffset(color: backGroundColorOfPaintingString) {
                     switch self.viewModel.editorDetailContent.version {
                     case .contents :
                             EditorDetailContentsVersionView(viewModel: self.viewModel, fileName: self.filename)
                                 .navigationBarHidden(true)
+                            .background(Color.white)
                     case .list :
                             EditorDetailListVersionView(viewModel: self.viewModel, fileName: self.filename)
                                 .navigationBarHidden(true)
+                            .background(Color.white)
                     }
                 } onOffsetChange: {
                     scrollOffset = $0
+                    if $0 > 100 {
+                        showModal.toggle()
+                    }
                 }
                 Button {
                     showModal.toggle()
@@ -52,6 +59,7 @@ struct EditorDetailView: View {
             }
             .ignoresSafeArea()
         }
+        .animation(Animation.easeIn(duration: 1), value: showModal)
         .accentColor(Color(hex: "4F4F4F"))
     }
 }

--- a/campair/campair/View/Editor/Main/EditorCardView.swift
+++ b/campair/campair/View/Editor/Main/EditorCardView.swift
@@ -50,10 +50,9 @@ struct EditorCardView: View {
         }
     }
 }
-//
-// struct EditorCardView_Previews: PreviewProvider {
-//    static var previews: some View {
-//        EditorCardView()
-//            .previewDevice("iPod touch (7th generation)")
-//    }
-// }
+
+ struct EditorCardView_Previews: PreviewProvider {
+    static var previews: some View {
+        EditorCardView(editorMainContent: .constant(EditorMainContent()), cardPaintingImage: Data())
+    }
+ }


### PR DESCRIPTION
# Issue Number
🔒 Close #147
🔒 Close #151

## Changes

- Changed files
	modified:   campair/campair.xcodeproj/project.pbxproj
	modified:   campair/campair/View/Editor/Detail/EditorDetailView/EditorDetailView.swift
	modified:   campair/campair/View/Editor/Main/EditorCardView.swift

## New features
- To turn off the screen when you drop down the Editor Detail View
- Resolve (only top part) Bug #151

## References
Resolve (only top part) Bug #151
Put ZStack inside the navigation and color 
Changed the color of the supposed view under Editor Detail View.
```
NavigationView {
    ZStack {
        // 윗영역 color 넣기 ex) Color.red
        ScrollView() {
            // 내용 입력
            }
        }
    }
}
```

## Review Potint
I googling and found this But I am not sure this is the best solution..
I wanna hear your voices.
And If I write code like this, there is an #153 issue..

## Before

https://user-images.githubusercontent.com/82457928/178499392-8c73fb1d-1bb7-48cb-b09b-0d74f76b9a06.mov



## After

https://user-images.githubusercontent.com/82457928/178499333-5e5550d2-7f2d-43d0-bb49-54f68ec1afd4.mov


## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
